### PR TITLE
delete distracting sites from storage

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -5,3 +5,29 @@ body {
   padding: 0;
   overflow: hidden;
 }
+
+#distracting-domains-container ul {
+  list-style: none;
+  padding: 0;
+}
+
+#distracting-domains-container li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+}
+
+#distracting-domains-container .delete-btn {
+  background-color: #ff4d4d;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#distracting-domains-container .delete-btn:hover {
+  background-color: #cc0000;
+}

--- a/html/pages/3.html
+++ b/html/pages/3.html
@@ -1,4 +1,16 @@
-<div>
-  <h2>Page 3</h2>
-  <p>Welcome to page 3!</p>
-</div>
+<!DOCTYPE html>
+<html>
+
+<head>
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+
+<body>
+  <div>
+    <h2>Manage Distracting Sites</h2>
+    <p>Here you can view and remove sites you have marked as distracting.</p>
+    <div id="distracting-domains-container"></div>
+  </div>
+</body>
+
+</html>

--- a/scripts/pages/3.js
+++ b/scripts/pages/3.js
@@ -1,0 +1,69 @@
+/**
+ * Fetches distracting domains from storage and displays them in a list.
+ * Each item in the list has a delete button.
+ */
+function displayAndDeleteDistractingDomains() {
+    const container = document.getElementById('distracting-domains-container');
+    container.innerHTML = ''; // Clear previous list
+
+    chrome.storage.sync.get(['distractingDomains'], (result) => {
+        const domains = result.distractingDomains || [];
+
+        if (domains.length === 0) {
+            container.textContent = "You haven't marked any sites as distracting yet.";
+            return;
+        }
+
+        const ul = document.createElement('ul');
+        domains.forEach(domain => {
+            const li = document.createElement('li');
+            
+            const domainText = document.createElement('span');
+            domainText.textContent = domain;
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.textContent = 'Delete';
+            deleteBtn.className = 'delete-btn';
+            
+            // Add event listener to the delete button
+            deleteBtn.addEventListener('click', () => {
+                deleteDomain(domain);
+            });
+
+            li.appendChild(domainText);
+            li.appendChild(deleteBtn);
+            ul.appendChild(li);
+        });
+
+        container.appendChild(ul);
+    });
+}
+
+/**
+ * Deletes a specific domain from the distracting domains list in storage,
+ * and then re-renders the list.
+ * @param {string} domainToDelete The domain to remove.
+ */
+function deleteDomain(domainToDelete) {
+    const storageKey = "distractingDomains";
+    chrome.storage.sync.get([storageKey], (result) => {
+        const domains = result[storageKey] || [];
+        // Filter out the domain to be deleted
+        const updatedDomains = domains.filter(d => d !== domainToDelete);
+        
+        // Save the updated list back to storage
+        chrome.storage.sync.set({ [storageKey]: updatedDomains }, () => {
+            console.log(`Deleted ${domainToDelete} from distracting domains list.`);
+            // Refresh the list view to show the change
+            displayAndDeleteDistractingDomains();
+        });
+    });
+}
+
+/**
+ * The init function that is called by main.js when this page is loaded.
+ */
+export function init() {
+    // Initial call to display the domains when the page loads
+    displayAndDeleteDistractingDomains();
+}


### PR DESCRIPTION
now you can delete your distracting sites from storage. if you go to page 3, any sites you have marked as distracting are listed. clicking on the button removes them from storage.