### PR TITLE
Lock tabs

### DIFF
--- a/html/locked.html
+++ b/html/locked.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Tab Locked</title>
+    <style>
+        body {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            font-family: sans-serif;
+            background-color: #f2f2f2;
+        }
+
+        #lock-container {
+            text-align: center;
+            background-color: white;
+            padding: 40px;
+            border-radius: 10px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+
+        input {
+            padding: 10px;
+            font-size: 16px;
+            margin-bottom: 10px;
+        }
+
+        button {
+            padding: 10px 20px;
+            font-size: 16px;
+            cursor: pointer;
+        }
+
+        #error-message {
+            color: red;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="lock-container">
+        <h2>This tab is locked</h2>
+        <p>Enter your PIN to unlock.</p>
+        <input type="password" id="pin-input" placeholder="PIN">
+        <button id="unlock-btn">Unlock</button>
+        <div id="error-message"></div>
+    </div>
+    <script src="../scripts/locked.js"></script>
+</body>
+
+</html>

--- a/html/main.html
+++ b/html/main.html
@@ -36,6 +36,7 @@
             <button data-page="1">Page 1</button>
             <button data-page="2">Page 2</button>
             <button data-page="3">Page 3</button>
+            <button data-page="4">Page 4</button>
         </div>
     </div>
     <div id="content"></div>

--- a/html/pages/1.html
+++ b/html/pages/1.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  
+
 <body>
   <h1>LockedIn</h1>
   <h2>Distracting Sites</h2>
@@ -8,9 +8,10 @@
   <div id="distracting-domains-container">
     <!-- The list of sites will be inserted here -->
   </div>
-  <hr></hr>
+  <hr>
+  </hr>
   <h2 id="time">00:00</h2>
-  <input id="time-input" type="text" placeholder="Enter time..."/>
+  <input id="time-input" type="text" placeholder="Enter time..." />
   <button type="submit">Submit</button>
   <button id="start-timer">Start timer</button>
   <button id="reset-timer">Reset timer</button>

--- a/html/pages/4.html
+++ b/html/pages/4.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Settings</title>
+    <style>
+        body { font-family: sans-serif; padding: 10px; }
+        #pin-container { display: flex; flex-direction: column; gap: 10px; width: 200px; }
+        input { padding: 5px; }
+        button { padding: 5px 10px; }
+        #pin-message { font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h2>Set Unlock PIN</h2>
+    <div id="pin-container">
+        <input type="password" id="pin-input" placeholder="Enter new PIN">
+        <input type="password" id="pin-confirm" placeholder="Confirm new PIN">
+        <button id="set-pin">Set PIN</button>
+        <div id="pin-message"></div>
+    </div>
+    <script src="../../scripts/pages/4.js"></script>
+</body>
+</html>

--- a/scripts/locked.js
+++ b/scripts/locked.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const pinInput = document.getElementById('pin-input');
+    const unlockBtn = document.getElementById('unlock-btn');
+    const errorMessage = document.getElementById('error-message');
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const targetUrl = urlParams.get('url');
+
+    unlockBtn.addEventListener('click', async () => {
+        const enteredPin = pinInput.value;
+        const { unlockPin } = await chrome.storage.local.get('unlockPin');
+
+        if (enteredPin === unlockPin) {
+            // Unlock for this session
+            const url = new URL(targetUrl);
+            const domain = url.hostname;
+            const sessionKey = `unlocked_${domain}`;
+            await chrome.storage.session.set({ [sessionKey]: true });
+
+            // Redirect to the original URL
+            window.location.href = targetUrl;
+        } else {
+            errorMessage.textContent = 'Incorrect PIN. Please try again.';
+            pinInput.value = "";
+        }
+    });
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5,7 +5,8 @@ const buttons = document.querySelectorAll("#page-buttons button");
 const PAGE_MAP = {
     1: { html: "../html/pages/1.html", script: "scripts/pages/1.js" },
     2: { html: "../html/pages/2.html", script: "scripts/pages/2.js" },
-    3: { html: "../html/pages/3.html", script: "scripts/pages/3.js" }
+    3: { html: "../html/pages/3.html", script: "scripts/pages/3.js" },
+    4: { html: "../html/pages/4.html", script: "scripts/pages/4.js" }
 };
 
 async function LoadPage(pageNum) {

--- a/scripts/pages/4.js
+++ b/scripts/pages/4.js
@@ -1,0 +1,31 @@
+export function init() {
+    const pinInput = document.getElementById('pin-input');
+    const pinConfirm = document.getElementById('pin-confirm');
+    const setPinBtn = document.getElementById('set-pin');
+    const pinMessage = document.getElementById('pin-message');
+
+    setPinBtn.addEventListener('click', () => {
+        const pin = pinInput.value;
+        const confirm = pinConfirm.value;
+
+        if (pin.length < 4) {
+            pinMessage.textContent = "PIN must be at least 4 digits.";
+            pinMessage.style.color = 'red';
+            return;
+        }
+
+        if (pin !== confirm) {
+            pinMessage.textContent = "PINs do not match.";
+            pinMessage.style.color = 'red';
+            return;
+        }
+
+        chrome.storage.local.set({ unlockPin: pin }, () => {
+            pinMessage.textContent = "PIN set successfully!";
+            pinMessage.style.color = 'green';
+            pinInput.value = "";
+            pinConfirm.value = "";
+        });
+    });
+}
+


### PR DESCRIPTION
When a user marks a tab as distracting, the domain is saved to storage. When a user clicks on a page with a domain from the list, the user is redirected to a new page where they have to input a PIN to unlock the page. The user sets their PIN in page 4 of the extension popup. 

Known issues:

The logic doesn't kick in until a page is marked as distracting and the user leaves the page or the tab becomes unfocused.